### PR TITLE
Add utility scripts to python_scripts

### DIFF
--- a/python_scripts/README.md
+++ b/python_scripts/README.md
@@ -1,12 +1,36 @@
 # Python Scripts
 
-This folder contains small standalone Python scripts. `hello_codex.py` demonstrates
-how to parse command line arguments with `argparse` and write the output to a file.
-It showcases Codex's ability to document code clearly and implement basic scripting
-patterns.
+This folder contains small, standalone scripts demonstrating useful patterns in Python.
+Each script can be run directly from the command line and is written to be easy
+to read, reuse, or extend.
 
-Run it with:
+## Available Scripts
 
-```bash
-python hello_codex.py YourName -o greeting.txt
-```
+- **hello_codex.py** – simple example showing `argparse` and file output.
+  ```bash
+  python hello_codex.py YourName -o greeting.txt
+  ```
+- **file_organizer.py** – organize files into subfolders based on extension.
+  ```bash
+  python file_organizer.py /path/to/downloads --dry-run
+  ```
+- **pdf_to_text.py** – extract text from all PDFs in a folder using `PyPDF2`.
+  ```bash
+  python pdf_to_text.py ./pdfs -o texts
+  ```
+- **log_parser.py** – count ERROR/WARNING/INFO entries in a log file.
+  ```bash
+  python log_parser.py system.log --csv summary.csv
+  ```
+- **markdown_table_generator.py** – convert a CSV file to a Markdown table.
+  ```bash
+  python markdown_table_generator.py data.csv -o table.md
+  ```
+
+## Dependencies
+
+Only `pdf_to_text.py` requires an external dependency:
+
+- `PyPDF2` – install with `pip install PyPDF2`
+
+All other scripts rely solely on Python's standard library.

--- a/python_scripts/file_organizer.py
+++ b/python_scripts/file_organizer.py
@@ -1,0 +1,59 @@
+"""File Organizer
+-----------------
+Organize files in a folder into subfolders by file extension.
+
+Usage::
+    python file_organizer.py /path/to/folder [--dry-run]
+
+The script creates subfolders (e.g. 'txt', 'jpg') in the target directory
+and moves files accordingly. Use ``--dry-run`` to preview actions without
+modifying the filesystem.
+"""
+
+import argparse
+import os
+import shutil
+from typing import Iterable
+
+
+def get_files(directory: str) -> Iterable[str]:
+    """Yield file names (not directories) in *directory*."""
+    for entry in os.scandir(directory):
+        if entry.is_file():
+            yield entry.name
+
+
+def ensure_folder(path: str) -> None:
+    """Create folder ``path`` if it does not exist."""
+    os.makedirs(path, exist_ok=True)
+
+
+def organize(directory: str, dry_run: bool = False) -> None:
+    """Move files in *directory* into subfolders by extension."""
+    for name in get_files(directory):
+        base, ext = os.path.splitext(name)
+        ext_folder = ext[1:].lower() or "no_extension"
+        dest_dir = os.path.join(directory, ext_folder)
+        ensure_folder(dest_dir)
+        src = os.path.join(directory, name)
+        dst = os.path.join(dest_dir, name)
+        if dry_run:
+            print(f"Would move {src} -> {dst}")
+        else:
+            shutil.move(src, dst)
+            print(f"Moved {src} -> {dst}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Organize files by extension")
+    parser.add_argument("path", help="Target directory")
+    parser.add_argument("--dry-run", action="store_true", help="Preview actions")
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.path):
+        parser.error(f"{args.path} is not a directory")
+    organize(args.path, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/python_scripts/log_parser.py
+++ b/python_scripts/log_parser.py
@@ -1,0 +1,75 @@
+"""Log Parser
+-----------
+Summarize log levels (ERROR, WARNING, INFO) in a log file. Optionally group by
+date if the log begins with a ``YYYY-MM-DD`` timestamp.
+
+Usage::
+    python log_parser.py path/to/logfile [--csv summary.csv]
+"""
+
+import argparse
+import csv
+import os
+import re
+from collections import defaultdict
+from typing import Dict, Iterable
+
+LEVELS = ("ERROR", "WARNING", "INFO")
+
+
+def parse_lines(lines: Iterable[str]) -> Dict[str, Dict[str, int]]:
+    """Return counts of levels by date.
+
+    If no date is found in a line, all counts are stored under ``"all"``.
+    """
+    totals: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    date_re = re.compile(r"^(?P<date>\d{4}-\d{2}-\d{2})")
+    level_re = re.compile(r"\b(ERROR|WARNING|INFO)\b")
+
+    for line in lines:
+        date_match = date_re.match(line)
+        date = date_match.group("date") if date_match else "all"
+        level_match = level_re.search(line)
+        if level_match:
+            level = level_match.group(1)
+            totals[date][level] += 1
+    return totals
+
+
+def print_summary(stats: Dict[str, Dict[str, int]]) -> None:
+    """Print a formatted summary to stdout."""
+    for date, counts in sorted(stats.items()):
+        summary = ", ".join(f"{lvl}: {counts.get(lvl,0)}" for lvl in LEVELS)
+        print(f"{date} -> {summary}")
+
+
+def write_csv(stats: Dict[str, Dict[str, int]], csv_path: str) -> None:
+    """Write summary statistics to ``csv_path``."""
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["date", *LEVELS])
+        for date, counts in sorted(stats.items()):
+            row = [date] + [counts.get(lvl, 0) for lvl in LEVELS]
+            writer.writerow(row)
+    print(f"Wrote {csv_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Parse log file for level counts")
+    parser.add_argument("logfile", help="Path to log file")
+    parser.add_argument("--csv", help="Optional output CSV path")
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.logfile):
+        parser.error(f"{args.logfile} is not a file")
+    with open(args.logfile, "r", encoding="utf-8", errors="ignore") as f:
+        stats = parse_lines(f)
+
+    if args.csv:
+        write_csv(stats, args.csv)
+    else:
+        print_summary(stats)
+
+
+if __name__ == "__main__":
+    main()

--- a/python_scripts/markdown_table_generator.py
+++ b/python_scripts/markdown_table_generator.py
@@ -1,0 +1,65 @@
+"""Markdown Table Generator
+-------------------------
+Convert a CSV file into a Markdown-formatted table.
+
+Example::
+    python markdown_table_generator.py data.csv -d ';' -o table.md
+"""
+
+import argparse
+import csv
+import os
+from typing import List
+
+
+def escape_pipe(text: str) -> str:
+    """Escape pipe characters used in Markdown tables."""
+    return text.replace("|", "\\|")
+
+
+def read_csv(path: str, delimiter: str) -> List[List[str]]:
+    """Return rows from CSV file as list of lists."""
+    with open(path, newline="", encoding="utf-8") as f:
+        return [row for row in csv.reader(f, delimiter=delimiter)]
+
+
+def to_markdown(rows: List[List[str]]) -> str:
+    """Convert rows to a Markdown table string."""
+    if not rows:
+        return ""
+    header, *body = rows
+    header = [escape_pipe(cell) for cell in header]
+    lines = ["| " + " | ".join(header) + " |"]
+    lines.append("|" + "|".join([" --- " for _ in header]) + "|")
+    for row in body:
+        row = [escape_pipe(cell) for cell in row]
+        lines.append("| " + " | ".join(row) + " |")
+    return "\n".join(lines)
+
+
+def write_output(text: str, path: str = None) -> None:
+    """Write Markdown to *path* or print to stdout."""
+    if path:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(text + "\n")
+        print(f"Wrote {path}")
+    else:
+        print(text)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate Markdown table from CSV")
+    parser.add_argument("csvfile", help="Path to CSV file")
+    parser.add_argument("-d", "--delimiter", default=",", help="CSV delimiter")
+    parser.add_argument("-o", "--output", help="Output file (defaults to stdout)")
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.csvfile):
+        parser.error(f"{args.csvfile} is not a file")
+    rows = read_csv(args.csvfile, args.delimiter)
+    markdown = to_markdown(rows)
+    write_output(markdown, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/python_scripts/pdf_to_text.py
+++ b/python_scripts/pdf_to_text.py
@@ -1,0 +1,59 @@
+"""PDF to Text Converter
+-----------------------
+Extract text content from all PDF files in a folder.
+
+Requires ``PyPDF2``. Example::
+    python pdf_to_text.py /path/to/pdfs -o output_folder
+"""
+
+import argparse
+import os
+from pathlib import Path
+from typing import Iterable
+
+from PyPDF2 import PdfReader
+
+
+def pdf_files(directory: str) -> Iterable[Path]:
+    """Yield ``Path`` objects for PDF files inside *directory*."""
+    for entry in Path(directory).iterdir():
+        if entry.is_file() and entry.suffix.lower() == ".pdf":
+            yield entry
+
+
+def extract_text(pdf_path: Path) -> str:
+    """Return the full text from a PDF file."""
+    try:
+        reader = PdfReader(str(pdf_path))
+        return "\n".join(page.extract_text() or "" for page in reader.pages)
+    except Exception as exc:  # catch parsing errors
+        raise RuntimeError(f"Failed to read {pdf_path}: {exc}")
+
+
+def convert_all(src_dir: str, out_dir: str) -> None:
+    """Write text versions of all PDFs in ``src_dir`` to ``out_dir``."""
+    Path(out_dir).mkdir(parents=True, exist_ok=True)
+    for pdf in pdf_files(src_dir):
+        txt_path = Path(out_dir) / (pdf.stem + ".txt")
+        try:
+            text = extract_text(pdf)
+        except Exception as e:
+            print(e)
+            continue
+        txt_path.write_text(text, encoding="utf-8")
+        print(f"Wrote {txt_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Extract text from PDFs")
+    parser.add_argument("src", help="Folder containing PDF files")
+    parser.add_argument("-o", "--output", default="texts", help="Output folder")
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.src):
+        parser.error(f"{args.src} is not a directory")
+    convert_all(args.src, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `file_organizer.py` to organize files by extension
- add `pdf_to_text.py` for extracting PDF text with PyPDF2
- add `log_parser.py` to summarize log levels
- add `markdown_table_generator.py` for converting CSV to Markdown tables
- update `python_scripts/README.md` with usage info

## Testing
- `python -m py_compile hello_codex.py file_organizer.py pdf_to_text.py log_parser.py markdown_table_generator.py`
- `python file_organizer.py /tmp/test_files --dry-run`
- `python pdf_to_text.py /tmp/test_files` *(fails: ModuleNotFoundError: No module named 'PyPDF2')*
- `python log_parser.py sample.log`
- `python markdown_table_generator.py sample.csv`

------
https://chatgpt.com/codex/tasks/task_e_685d8b925d748331bffc29ad39f9159f