### PR TITLE
Add RAG notebooks

### DIFF
--- a/rag/README.md
+++ b/rag/README.md
@@ -1,0 +1,34 @@
+# Retrieval-Augmented Generation Examples
+
+This folder contains educational notebooks showing how to build small RAG pipelines with persistent storage. The goal is to demonstrate how language models can use external knowledge bases for improved answers.
+
+## What's Inside?
+
+| Notebook | Summary |
+|----------|---------|
+| `basic_rag_with_chromadb.ipynb` | Minimal RAG pipeline using ChromaDB for document storage and retrieval. |
+| `rag_with_multiple_search_modes.ipynb` | Compare similarity search strategies such as cosine similarity and maximal marginal relevance. |
+| `graph_rag_basics.ipynb` | Simple graph-based RAG example using a knowledge graph. |
+
+### Dependencies
+
+These notebooks rely on the following libraries:
+
+- `chromadb` for a persistent vector database.
+- `sentence-transformers` or `openai` embeddings.
+- `langchain` for RAG utilities.
+- `networkx` or `neo4j` for graph examples.
+
+Install everything with:
+
+```bash
+pip install chromadb sentence-transformers langchain openai networkx neo4j
+```
+
+Some notebooks may require API keys for certain embedding or LLM services. Refer to the comments inside each notebook.
+
+## Classic RAG vs Graph RAG
+
+Classic RAG retrieves semantically similar documents from a vector store and feeds them to an LLM. Graph RAG also reasons over relationships in a knowledge graph before querying the language model. This can improve precision for structured data like research papers or organizational charts.
+
+Use these notebooks as starting points for your own retrieval pipelines.

--- a/rag/basic_rag_with_chromadb.ipynb
+++ b/rag/basic_rag_with_chromadb.ipynb
@@ -1,0 +1,104 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Basic RAG with ChromaDB\n",
+    "This notebook demonstrates a minimal Retrieval-Augmented Generation (RAG) pipeline using **ChromaDB** as a persistent vector store."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RAG works by retrieving documents relevant to a user's question and feeding them to a language model.\n",
+    "Here the steps are:\n",
+    "1. Embed the question and documents using a sentence transformer.\n",
+    "2. Perform a similarity search in ChromaDB.\n",
+    "3. Compose a prompt with the retrieved docs.\n",
+    "4. Ask an LLM to answer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```",
+    "User question -> embedding -> retrieval -> prompt -> answer",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install dependencies if needed",
+    "# !pip install chromadb langchain sentence-transformers openai"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.embeddings import HuggingFaceEmbeddings\n",
+    "from langchain.vectorstores import Chroma\n",
+    "from langchain.llms import OpenAI\n",
+    "from langchain.chains import RetrievalQA\n",
+    "\n",
+    "DB_DIR = 'rag_db'\n",
+    "embeddings = HuggingFaceEmbeddings(model_name='all-MiniLM-L6-v2')\n",
+    "\n",
+    "texts = [\n",
+    "    'Small dogs are friendly and great for apartments.',\n",
+    "    'Large dogs require more space and daily exercise.',\n",
+    "    'Cats are independent pets that enjoy quiet environments.'\n",
+    "]\n",
+    "metadatas = [{'source': f'doc{i}'} for i in range(len(texts))]\n",
+    "\n",
+    "vectordb = Chroma.from_texts(texts, embeddings, metadatas=metadatas, persist_directory=DB_DIR)\n",
+    "vectordb.persist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qa = RetrievalQA.from_chain_type(llm=OpenAI(temperature=0), chain_type='stuff', retriever=vectordb.as_retriever())\n",
+    "query = 'Which pets are good for apartments?'\n",
+    "result = qa({'query': query})\n",
+    "print('Answer:', result['result'])\n",
+    "\n",
+    "docs = vectordb.similarity_search(query, k=2)\n",
+    "for doc in docs:\n",
+    "    print(doc.page_content, '->', doc.metadata)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The output shows which documents were retrieved to answer the question. Persistence is handled via `vectordb.persist()` so re-running the notebook keeps the data on disk."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/rag/graph_rag_basics.ipynb
+++ b/rag/graph_rag_basics.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Graph RAG Basics\nThis notebook introduces the idea of combining a knowledge graph with vector retrieval for question answering."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll build a tiny graph of authors and their publications using `networkx`. The graph can be traversed to answer questions like *What has John Smith published?*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import networkx as nx\nG = nx.DiGraph()\nG.add_edge('John Smith','Paper A')\nG.add_edge('John Smith','Paper B')\nG.add_edge('Jane Doe','Paper C')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def publications(author):\n    return list(G.successors(author))\n\nprint(publications('John Smith'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In a graph RAG system, the results from the graph traversal would be combined with text retrieved from a vector store before asking the LLM. This works well when relationships between entities are important."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/rag/rag_with_multiple_search_modes.ipynb
+++ b/rag/rag_with_multiple_search_modes.ipynb
@@ -1,0 +1,65 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# RAG with Multiple Search Modes\nThis notebook compares different retrieval strategies in ChromaDB and how they affect a simple RAG pipeline."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will experiment with cosine similarity, maximal marginal relevance (MMR), and a naive hybrid approach."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.embeddings import HuggingFaceEmbeddings\nfrom langchain.vectorstores import Chroma\nfrom langchain.llms import OpenAI\nfrom langchain.chains import RetrievalQA\n\nDB_DIR = 'rag_db'\nembeddings = HuggingFaceEmbeddings(model_name='all-MiniLM-L6-v2')\n\n# Load the same documents as in the basic notebook\nvectordb = Chroma(persist_directory=DB_DIR, embedding_function=embeddings)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ask(query, mode='similarity'):\n    if mode == 'mmr':\n        retriever = vectordb.as_retriever(search_type='mmr', search_kwargs={'k':3})\n    elif mode == 'hybrid':\n        retriever = vectordb.as_retriever(search_kwargs={'k':2})\n        # simple hybrid example: rerun with mmr for diversity\n        retriever_mmr = vectordb.as_retriever(search_type='mmr', search_kwargs={'k':1})\n        retriever.search = lambda q: retriever.search(q) + retriever_mmr.search(q)\n    else:\n        retriever = vectordb.as_retriever(search_kwargs={'k':3})\n    qa = RetrievalQA.from_chain_type(llm=OpenAI(temperature=0), chain_type='stuff', retriever=retriever)\n    return qa({'query': query})['result']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for mode in ['similarity','mmr','hybrid']:\n    answer = ask('Which pets are good for apartments?', mode=mode)\n    print(f'--- {mode} ---')\n    print(answer)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Cosine similarity often retrieves the most relevant documents but may include redundancy. MMR tries to diversify results, while the hybrid approach combines them. Timings and token counts will vary depending on the dataset size."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- introduce new **rag/** folder
- add a README explaining Retrieval-Augmented Generation
- create a basic RAG notebook with ChromaDB persistence
- show how to switch search strategies
- demonstrate a minimal graph-based RAG example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d9e8058148331a15152dbc24d7cb9