### PR TITLE
Add LM Studio memory demo

### DIFF
--- a/ml_demos/README.md
+++ b/ml_demos/README.md
@@ -16,6 +16,7 @@ This folder contains small notebooks demonstrating common machine learning workf
 ## Script
 
 - **mlflow_integration_example.py** – Utility script showing how to log parameters, metrics and a model to MLflow.
+- **llm_memory_demo.py** – Demonstrates a simple long‑term memory system for a local model served with LM Studio. See `llm_memory_demo.md` for details.
 
 ## References
 

--- a/ml_demos/llm_memory_demo.md
+++ b/ml_demos/llm_memory_demo.md
@@ -1,0 +1,55 @@
+# LLM Memory Demo
+
+This document explains how `llm_memory_demo.py` uses a simple external store to simulate long‑term memory when chatting with a model served through **LM Studio**.
+
+## Stateless vs. Stateful LLMs
+
+Large language models are stateless by design: each request is independent and the model only considers the prompt you send. By persisting past interactions and adding the most relevant snippets back into the prompt, we can create the illusion of stateful, memory‑driven behavior.
+
+## Memory in a RAG Pipeline
+
+In retrieval‑augmented generation (RAG) pipelines, context retrieved from a knowledge base is combined with the user's current question. Conversation memory is just another source of context that can be appended to the prompt before calling the model.
+
+```
+[user question] + [retrieved docs] + [retrieved memory] -> LLM
+```
+
+## Short‑Term vs. Long‑Term Memory
+
+- **Short‑term memory** is the model's context window. Anything outside that window is forgotten when the response is generated.
+- **Long‑term memory** keeps a history in an external store (JSON or a database). Only the most relevant pieces are injected back into the context window for each request.
+
+## Workflow Diagram
+
+```
+        +-------------+
+        | User Input  |
+        +------+------+      retrieve top-N
+               |               memories
+               v
+       +-------+------+
+       | Memory Store |<----+
+       +-------+------+
+               | write new
+               | interaction
+               v
+     +---------+-----------+
+     | Prompt Assembly      |
+     +---------+-----------+
+               |
+               v
+        +------+------+
+        | LM Studio   |
+        +-------------+
+```
+
+## Running the Script
+
+Install the dependencies and start LM Studio so it exposes the HTTP API (by default on port 1234):
+
+```bash
+pip install requests sentence-transformers
+python llm_memory_demo.py --model mistral
+```
+
+The script stores conversations in `memory.json`. Delete the file to start over or inspect it to see what the model "remembers".

--- a/ml_demos/llm_memory_demo.py
+++ b/ml_demos/llm_memory_demo.py
@@ -1,0 +1,107 @@
+import argparse
+import json
+import os
+from datetime import datetime
+from typing import List, Dict, Any
+
+import requests
+
+try:
+    from sentence_transformers import SentenceTransformer, util
+except ImportError:  # pragma: no cover - optional dependency
+    SentenceTransformer = None
+    util = None
+
+API_URL = "http://localhost:1234/v1/chat/completions"
+
+
+def load_history(path: str) -> List[Dict[str, Any]]:
+    if not os.path.exists(path):
+        return []
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_history(path: str, history: List[Dict[str, Any]]) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(history, f, indent=2)
+
+
+def retrieve_context(query: str, history: List[Dict[str, Any]], model: Any, top_k: int) -> List[Dict[str, Any]]:
+    if not history:
+        return []
+    if model and util:
+        query_vec = model.encode(query)
+        scored = []
+        for item in history:
+            if item.get("embedding") is not None:
+                score = float(util.cos_sim(query_vec, item["embedding"]))
+                scored.append((score, item))
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return [item for _, item in scored[:top_k]]
+    return history[-top_k:]
+
+
+def build_messages(system_prompt: str, context: List[Dict[str, Any]], user_input: str) -> List[Dict[str, str]]:
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    for item in context:
+        messages.append({"role": "user", "content": item["user"]})
+        messages.append({"role": "assistant", "content": item["assistant"]})
+    messages.append({"role": "user", "content": user_input})
+    return messages
+
+
+def chat_loop(args: argparse.Namespace) -> None:
+    history = load_history(args.memory)
+    embedder = None
+    if SentenceTransformer and args.embedding_model:
+        embedder = SentenceTransformer(args.embedding_model)
+    while True:
+        try:
+            user_input = input("You: ")
+        except (EOFError, KeyboardInterrupt):
+            print()
+            break
+        if user_input.lower().strip() in {"exit", "quit"}:
+            break
+
+        context = retrieve_context(user_input, history, embedder, args.top_k)
+        messages = build_messages(args.system_prompt, context, user_input)
+        payload = {
+            "model": args.model,
+            "messages": messages,
+            "temperature": args.temperature,
+        }
+        resp = requests.post(API_URL, json=payload, timeout=30)
+        resp.raise_for_status()
+        assistant = resp.json()["choices"][0]["message"]["content"]
+        print(f"Assistant: {assistant}\n")
+
+        record = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "user": user_input,
+            "assistant": assistant,
+        }
+        if embedder:
+            record["embedding"] = embedder.encode(user_input).tolist()
+        history.append(record)
+        save_history(args.memory, history)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Simple memory demo with LM Studio")
+    p.add_argument("--model", default="lmstudio", help="Model name served by LM Studio")
+    p.add_argument("--system-prompt", default="You are a helpful assistant.")
+    p.add_argument("--temperature", type=float, default=0.7)
+    p.add_argument("--memory", default="memory.json", help="Path to JSON memory file")
+    p.add_argument("--embedding-model", default="all-MiniLM-L6-v2",
+                   help="SentenceTransformer model for embeddings")
+    p.add_argument("--top-k", type=int, default=3, help="Number of memories to retrieve")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    chat_loop(args)


### PR DESCRIPTION
## Summary
- add `llm_memory_demo.py` script showing how to store and retrieve conversation history for a local LLM served via LM Studio
- document the concept in `llm_memory_demo.md`
- list the new demo script in `ml_demos/README.md`

## Testing
- `python -m py_compile ml_demos/llm_memory_demo.py`

------
https://chatgpt.com/codex/tasks/task_e_685da4766db883319dbfe614ddd57196